### PR TITLE
-Crash fix: Stops bots from logging in multiple times.

### DIFF
--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -125,7 +125,12 @@ void PlayerbotHolder::HandlePlayerBotLoginCallback(QueryResult * dummy, SqlQuery
     WorldSession *botSession = new WorldSession(botAccountId, NULL, SEC_PLAYER, 0, LOCALE_enUS, "", 0);
     botSession->SetNoAnticheat();
 
+    // has bot already been added?
+    if (sObjectMgr.GetPlayer(lqh->GetGuid()))
+        return;
+
     uint32 guid = lqh->GetGuid().GetRawValue();
+
     botSession->HandlePlayerLogin(lqh); // will delete lqh
 
     Player* bot = botSession->GetPlayer();


### PR DESCRIPTION
## 🍰 Pullrequest
This PR fixes the ability for bots to login multiple times. This causes multiple issues most which lead to crashes.


### How2Test
Set RandomBotsPerInterval to a high number. Without this fix this will lead to random crashes which can be traced down to mutiple Player* having the same guid (and name)
