### PR TITLE
Accurate diff

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1077,7 +1077,7 @@ void Map::Update(const uint32& t_diff)
 
                 if (isInActiveArea && IsContinent())
                 {
-                    if (avgDiff > 150 && find(ActiveZones.begin(), ActiveZones.end(), obj->GetZoneId()) == ActiveZones.end())
+                    if (avgDiff > 150 && find(m_activeZones.begin(), m_activeZones.end(), obj->GetZoneId()) == m_activeZones.end())
                         isInActiveArea = false;
                 }
 

--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -977,8 +977,8 @@ void Map::Update(const uint32& t_diff)
 
     bool hasPlayers = false;
     uint32 activeChars = 0;
-    uint32 maxDiff = sWorld.GetMaxDiff();
-    bool updateAI = urand(0, (HasRealPlayers() ? maxDiff : (maxDiff * 3))) < 10;
+    uint32 avgDiff = sWorld.GetAverageDiff();
+    bool updateAI = urand(0, (HasRealPlayers() ? avgDiff : (avgDiff * 3))) < 10;
     /// update players at tick
     for (m_mapRefIter = m_mapRefManager.begin(); m_mapRefIter != m_mapRefManager.end(); ++m_mapRefIter)
     {
@@ -1003,7 +1003,7 @@ void Map::Update(const uint32& t_diff)
 
                 /*if (isInActiveArea)
                 {
-                    if (maxDiff > 200 && IsContinent())
+                    if (avgDiff > 200 && IsContinent())
                     {
                         if (find(m_activeZones.begin(), m_activeZones.end(), plr->GetZoneId()) == m_activeZones.end())
                             isInActiveArea = false;
@@ -1049,7 +1049,7 @@ void Map::Update(const uint32& t_diff)
     }
 
     // non-player active objects
-    bool updateObj = urand(0, (HasRealPlayers() ? maxDiff : (maxDiff * 3))) < 10;
+    bool updateObj = urand(0, (HasRealPlayers() ? avgDiff : (avgDiff * 3))) < 10;
     if (!m_activeNonPlayers.empty())
     {
         for (m_activeNonPlayersIter = m_activeNonPlayers.begin(); m_activeNonPlayersIter != m_activeNonPlayers.end();)
@@ -1065,7 +1065,7 @@ void Map::Update(const uint32& t_diff)
                 continue;
 
             // skip objects if world is laggy
-            if (IsContinent() && maxDiff > 100)
+            if (IsContinent() && avgDiff > 100)
             {
                 bool isInActiveArea = false;
 
@@ -1077,7 +1077,7 @@ void Map::Update(const uint32& t_diff)
 
                 if (isInActiveArea && IsContinent())
                 {
-                    if (maxDiff > 150 && find(m_activeZones.begin(), m_activeZones.end(), obj->GetZoneId()) == m_activeZones.end())
+                    if (avgDiff > 150 && find(ActiveZones.begin(), ActiveZones.end(), obj->GetZoneId()) == ActiveZones.end())
                         isInActiveArea = false;
                 }
 

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -111,6 +111,7 @@ uint32 World::m_currentDiffSum = 0;
 uint32 World::m_currentDiffSumIndex = 0;
 uint32 World::m_averageDiff = 0;
 uint32 World::m_maxDiff = 0;
+list<uint32> World::m_histDiff;
 
 /// World constructor
 World::World(): mail_timer(0), mail_timer_expires(0), m_NextWeeklyQuestReset(0), m_opcodeCounters(NUM_MSG_TYPES)

--- a/src/game/World/World.cpp
+++ b/src/game/World/World.cpp
@@ -1555,14 +1555,31 @@ void World::Update(uint32 diff)
     m_currentDiff = diff;
     m_currentDiffSum += diff;
     m_currentDiffSumIndex++;
-    if (m_currentDiffSumIndex && m_currentDiffSumIndex % 600 == 0)
+
+    m_histDiff.push_back(diff);
+    m_maxDiff = std::max(m_maxDiff, diff);
+
+    while(m_histDiff.size() >= 600)
     {
-        m_averageDiff = (uint32)(m_currentDiffSum / m_currentDiffSumIndex);
-        if (m_maxDiff < m_averageDiff)
-            m_maxDiff = m_averageDiff;
-        sLog.outBasic("Avg Diff: %u. Sessions online: %u.", m_averageDiff, (uint32)GetActiveSessionCount());
-        sLog.outBasic("Max Diff (last 5 min): %u.", m_maxDiff);
+        m_currentDiffSum -= m_histDiff.front();
+        m_histDiff.pop_front();
     }
+
+    m_averageDiff = (uint32)(m_currentDiffSum / m_histDiff.size());
+
+    if (m_currentDiffSumIndex && m_currentDiffSumIndex % 60 == 0)
+    {
+       //m_averageDiff = (uint32)(m_currentDiffSum / m_currentDiffSumIndex);
+        //if (m_maxDiff < m_averageDiff)
+        //    m_maxDiff = m_averageDiff;
+        sLog.outBasic("Avg Diff: %u. Sessions online: %u.", m_averageDiff, (uint32)GetActiveSessionCount());
+        sLog.outBasic("Max Diff: %u.", m_maxDiff);
+    }
+    if (m_currentDiffSum % 3000 == 0)
+    {
+        m_maxDiff = *std::max_element(m_histDiff.begin(), m_histDiff.end());
+    }
+    /*
     if (m_currentDiffSum > 300000)
     {
         m_currentDiffSum = 0;
@@ -1589,6 +1606,7 @@ void World::Update(uint32 diff)
             }
         }
     }
+    */
 
     ///- Update the different timers
     for (auto& m_timer : m_timers)

--- a/src/game/World/World.h
+++ b/src/game/World/World.h
@@ -811,6 +811,7 @@ class World
         static uint32 m_currentDiffSumIndex;
         static uint32 m_averageDiff;
         static uint32 m_maxDiff;
+        static std::list<uint32> m_histDiff;
 
         Messager<World> m_messager;
 


### PR DESCRIPTION
## 🍰 Pullrequest
This PR changes the calculation of avg/max diff to be more accurate based on all 600 values the last minute instead of 1-600 values. Max diff now takes all ticks into account and most diff throtling is switched from max to avg dif.
