### PR TITLE
Connect to bot session fix

### DIFF
--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -604,7 +604,33 @@ void WorldSession::HandlePlayerLoginOpcode(WorldPacket& recv_data)
         SendPacket(data, true);
         return;
     }
+#ifdef ENABLE_PLAYERBOTS
+    if (pCurrChar && pCurrChar->GetPlayerbotAI())
+    {
+        WorldSession* botSession = pCurrChar->GetSession();
+        SetPlayer(pCurrChar, playerGuid);
+        _player->SetSession(this);
+        _logoutTime = time(0);
 
+        m_sessionDbcLocale = botSession->m_sessionDbcLocale;
+        m_sessionDbLocaleIndex = botSession->m_sessionDbLocaleIndex;
+        
+        PlayerbotMgr* mgr = _player->GetPlayerbotMgr();
+        if (!mgr || mgr->GetMaster() != _player)
+        {
+            _player->SetPlayerbotMgr(NULL);
+            delete mgr;
+            _player->SetPlayerbotMgr(new PlayerbotMgr(_player));
+            _player->GetPlayerbotMgr()->OnPlayerLogin(_player);
+
+            if (sRandomPlayerbotMgr.GetPlayerBot(playerGuid))
+
+                sRandomPlayerbotMgr.MovePlayerBot(playerGuid, _player->GetPlayerbotMgr());
+            else
+                _player->GetPlayerbotMgr()->OnBotLogin(_player);
+        }
+    }
+#endif
     if (_player)
     {
         // player is reconnecting

--- a/src/game/Entities/CharacterHandler.cpp
+++ b/src/game/Entities/CharacterHandler.cpp
@@ -236,11 +236,9 @@ class CharacterHandler
             Player* player = sObjectMgr.GetPlayer(guid, true);
             if (player)
             {
-                if (!sRandomPlayerbotMgr.IsRandomBot(player))
-                {
-                    player->SetPlayerbotMgr(new PlayerbotMgr(player));
-                    player->GetPlayerbotMgr()->OnPlayerLogin(player);
-                }
+                player->SetPlayerbotMgr(new PlayerbotMgr(player));
+                player->GetPlayerbotMgr()->OnPlayerLogin(player);
+
                 sRandomPlayerbotMgr.OnPlayerLogin(player);
             }
 #endif


### PR DESCRIPTION
## 🍰 Pullrequest
This PR will fix some issues that happen when logging into active bots (alts, randombots, ect.). It used the normal system that is used when reconnecting to your character after you disconnect.

It also has a change that creates a botholder even when logging into random/always bots. Without this you aren't able to summon/control bots.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
