### PR TITLE
Allow move path to specify if the path is cyclical or not

### DIFF
--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -417,12 +417,12 @@ void MotionMaster::MovePointTOL(uint32 id, float x, float y, float z, bool takeO
     Mutate(new PointTOLMovementGenerator(id, x, y, z, takeOff, forcedMovement));
 }
 
-void MotionMaster::MovePath(std::vector<G3D::Vector3>& path, ForcedMovement forcedMovement, bool flying)
+void MotionMaster::MovePath(std::vector<G3D::Vector3>& path, ForcedMovement forcedMovement, bool flying, bool cyclic)
 {
-    return MovePath(path, 0, forcedMovement, flying);
+    return MovePath(path, 0, forcedMovement, flying, cyclic);
 }
 
-void MotionMaster::MovePath(std::vector<G3D::Vector3>& path, float o, ForcedMovement forcedMovement, bool flying)
+void MotionMaster::MovePath(std::vector<G3D::Vector3>& path, float o, ForcedMovement forcedMovement, bool flying, bool cyclic)
 {
     if (path.empty())
         return;
@@ -435,7 +435,7 @@ void MotionMaster::MovePath(std::vector<G3D::Vector3>& path, float o, ForcedMove
     else
         DEBUG_FILTER_LOG(LOG_FILTER_AI_AND_MOVEGENSS, "%s follows a pre-calculated path to X: %f Y: %f Z: %f", m_owner->GetGuidStr().c_str(), x, y, z);
 
-    Mutate(new FixedPathMovementGenerator(path, o, forcedMovement, flying));
+    Mutate(new FixedPathMovementGenerator(path, o, forcedMovement, flying, 0.0f, 0, cyclic));
 }
 
 void MotionMaster::MovePath(int32 pathId, WaypointPathOrigin wpOrigin /*= PATH_NO_PATH*/, ForcedMovement forcedMovement, bool flying, float speed, bool cyclic, ObjectGuid guid/* = ObjectGuid()*/)

--- a/src/game/MotionGenerators/MotionMaster.h
+++ b/src/game/MotionGenerators/MotionMaster.h
@@ -175,8 +175,8 @@ class MotionMaster : private std::stack<MovementGenerator*>
         void MovePoint(uint32 id, Position const& position, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, float speed = 0.f, bool generatePath = true, ObjectGuid guid = ObjectGuid(), uint32 relayId = 0);
         void MovePoint(uint32 id, float x, float y, float z, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, bool generatePath = true);
         void MovePointTOL(uint32 id, float x, float y, float z, bool takeOff, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE);
-        void MovePath(std::vector<G3D::Vector3>& path, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, bool flying = false);
-        void MovePath(std::vector<G3D::Vector3>& path, float o, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, bool flying = false);
+        void MovePath(std::vector<G3D::Vector3>& path, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, bool flying = false, bool cyclic = true);
+        void MovePath(std::vector<G3D::Vector3>& path, float o, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, bool flying = false, bool cyclic = true);
         // MovePath can not change speed or flying mid path due to how it works - if you wish to do that, split it into two paths
         void MovePath(int32 pathId = 0, WaypointPathOrigin wpOrigin = PATH_NO_PATH, ForcedMovement forcedMovement = FORCED_MOVEMENT_NONE, bool flying = false, float speed = 0.f, bool cyclic = false, ObjectGuid guid = ObjectGuid());
         void MoveRetreat(float x, float y, float z, float o, uint32 delay);

--- a/src/game/MotionGenerators/PathMovementGenerator.cpp
+++ b/src/game/MotionGenerators/PathMovementGenerator.cpp
@@ -26,8 +26,8 @@
 
 #include <algorithm>
 
-AbstractPathMovementGenerator::AbstractPathMovementGenerator(const Movement::PointsArray& path, float orientation, int32 offset/* = 0*/) :
-    m_pathIndex(offset), m_orientation(orientation), m_speedChanged(false), m_firstCycle(false), m_startPoint(0)
+AbstractPathMovementGenerator::AbstractPathMovementGenerator(const Movement::PointsArray& path, float orientation, int32 offset/* = 0*/, bool cyclic/* = true*/) :
+    m_pathIndex(offset), m_orientation(orientation), m_speedChanged(false), m_firstCycle(false), m_startPoint(0), m_cyclic(cyclic)
 {
     for (size_t i = 0; i < path.size(); ++i)
         m_path[i] = { path[i].x, path[i].y, path[i].z, ((i + 1) == path.size() ? orientation : 0), 0, 0 };

--- a/src/game/MotionGenerators/PathMovementGenerator.h
+++ b/src/game/MotionGenerators/PathMovementGenerator.h
@@ -29,7 +29,7 @@
 class AbstractPathMovementGenerator : public MovementGenerator
 {
     public:
-        explicit AbstractPathMovementGenerator(const Movement::PointsArray& path, float orientation = 0, int32 offset = 0);
+        explicit AbstractPathMovementGenerator(const Movement::PointsArray& path, float orientation = 0, int32 offset = 0, bool cyclic = true);
         explicit AbstractPathMovementGenerator(const WaypointPath* path, int32 offset = 0, bool cyclic = false, ObjectGuid guid = ObjectGuid());
 
         void Initialize(Unit& owner) override;
@@ -61,9 +61,9 @@ class AbstractPathMovementGenerator : public MovementGenerator
 class FixedPathMovementGenerator : public AbstractPathMovementGenerator
 {
     public:
-        FixedPathMovementGenerator(const Movement::PointsArray &path, float orientation, uint32 forcedMovement, bool flying = false, float speed = 0, int32 offset = 0) :
-            AbstractPathMovementGenerator(path, orientation, offset), m_flying(flying), m_speed(speed), m_forcedMovement(forcedMovement) {}
-        FixedPathMovementGenerator(const Movement::PointsArray& path, uint32 forcedMovement, bool flying = false, float speed = 0, int32 offset = 0) :
+        FixedPathMovementGenerator(const Movement::PointsArray &path, float orientation, uint32 forcedMovement, bool flying = false, float speed = 0, int32 offset = 0, bool cyclic = true) :
+            AbstractPathMovementGenerator(path, orientation, offset, cyclic), m_flying(flying), m_speed(speed), m_forcedMovement(forcedMovement) {}
+        FixedPathMovementGenerator(const Movement::PointsArray& path, uint32 forcedMovement, bool flying = false, float speed = 0, int32 offset = 0, bool cyclic = true) :
             FixedPathMovementGenerator(path, 0, forcedMovement, flying, speed, offset) {}
         FixedPathMovementGenerator(Unit& unit, int32 pathId, WaypointPathOrigin wpOrigin, ForcedMovement forcedMovement, bool flying = false, float speed = 0, int32 offset = 0, bool cyclic = false, ObjectGuid guid = ObjectGuid());
         FixedPathMovementGenerator(Creature& creature);


### PR DESCRIPTION
## 🍰 Pullrequest
Add an extra parameter to specify if the path is cyclical or not (if the start and end of the path is the same point or not). This is used for bots with custom path, we don't want them to start and end on the same point.

### Proof
<!-- Link resources as proof -->
- None

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### How2Test
<!-- Give a detailed description how to test your PR and confirm it is working as expected.
- Test1
- Test2
-->
- None

### Todo / Checklist
<!-- In case some parts are still missing, important notes, breaking changes and other notable items, list them here. -->
- [X] None
