### PR TITLE
Add guild MOTD, pnote and offnote commands

### DIFF
--- a/src/game/Chat/Chat.cpp
+++ b/src/game/Chat/Chat.cpp
@@ -322,6 +322,9 @@ ChatCommand* ChatHandler::getCommandTable()
         { "invite",         SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildInviteCommand,         "", nullptr },
         { "uninvite",       SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildUninviteCommand,       "", nullptr },
         { "rank",           SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildRankCommand,           "", nullptr },
+        { "motd",           SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildMotdCommand,           "", nullptr },
+        { "pnote",          SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildPnoteCommand,          "", nullptr },
+        { "offnote",        SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildOffnoteCommand,        "", nullptr },
         { nullptr,          0,                  false, nullptr,                                        "", nullptr }
     };
 

--- a/src/game/Chat/Chat.h
+++ b/src/game/Chat/Chat.h
@@ -347,6 +347,9 @@ class ChatHandler
         bool HandleGuildUninviteCommand(char* args);
         bool HandleGuildRankCommand(char* args);
         bool HandleGuildDeleteCommand(char* args);
+        bool HandleGuildMotdCommand(char* args);
+        bool HandleGuildPnoteCommand(char* args);
+        bool HandleGuildOffnoteCommand(char* args);
 
         bool HandleHonorShow(char* args);
         bool HandleHonorAddCommand(char* args);

--- a/src/game/Chat/Level3.cpp
+++ b/src/game/Chat/Level3.cpp
@@ -2796,6 +2796,112 @@ bool ChatHandler::HandleGuildDeleteCommand(char* args)
     return true;
 }
 
+bool ChatHandler::HandleGuildMotdCommand(char* args)
+{
+    char* guildStr = ExtractQuotedArg(&args);
+    if (!guildStr)
+        return false;
+
+    char* motdStr = ExtractQuotedArg(&args);
+    if (!motdStr)
+        return false;
+
+    Guild* targetGuild = sGuildMgr.GetGuildByName(guildStr);
+    if (!targetGuild)
+    {
+        PSendSysMessage("Guild not found: %s", guildStr);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    targetGuild->SetMOTD(motdStr);
+    targetGuild->BroadcastEvent(GE_MOTD, motdStr);
+    PSendSysMessage("Guild MOTD for [%s] updated.", guildStr);
+    return true;
+}
+
+bool ChatHandler::HandleGuildPnoteCommand(char* args)
+{
+    Player* target = nullptr;
+    ObjectGuid targetGuid;
+    std::string targetName;
+    if (!ExtractPlayerTarget(&args, &target, &targetGuid, &targetName))
+        return false;
+
+    char* noteStr = ExtractQuotedArg(&args);
+    if (!noteStr)
+        return false;
+
+    uint32 guildId = target ? target->GetGuildId() : Player::GetGuildIdFromDB(targetGuid);
+    if (!guildId)
+    {
+        PSendSysMessage("%s is not in a guild.", targetName.c_str());
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    Guild* targetGuild = sGuildMgr.GetGuildById(guildId);
+    if (!targetGuild)
+    {
+        PSendSysMessage("Could not find guild for %s.", targetName.c_str());
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    MemberSlot* slot = targetGuild->GetMemberSlot(targetGuid);
+    if (!slot)
+    {
+        PSendSysMessage("Could not find guild member slot for %s.", targetName.c_str());
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    slot->SetPNOTE(noteStr);
+    PSendSysMessage("Public note for %s updated.", targetName.c_str());
+    return true;
+}
+
+bool ChatHandler::HandleGuildOffnoteCommand(char* args)
+{
+    Player* target = nullptr;
+    ObjectGuid targetGuid;
+    std::string targetName;
+    if (!ExtractPlayerTarget(&args, &target, &targetGuid, &targetName))
+        return false;
+
+    char* noteStr = ExtractQuotedArg(&args);
+    if (!noteStr)
+        return false;
+
+    uint32 guildId = target ? target->GetGuildId() : Player::GetGuildIdFromDB(targetGuid);
+    if (!guildId)
+    {
+        PSendSysMessage("%s is not in a guild.", targetName.c_str());
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    Guild* targetGuild = sGuildMgr.GetGuildById(guildId);
+    if (!targetGuild)
+    {
+        PSendSysMessage("Could not find guild for %s.", targetName.c_str());
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    MemberSlot* slot = targetGuild->GetMemberSlot(targetGuid);
+    if (!slot)
+    {
+        PSendSysMessage("Could not find guild member slot for %s.", targetName.c_str());
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    slot->SetOFFNOTE(noteStr);
+    PSendSysMessage("Officer note for %s updated.", targetName.c_str());
+    return true;
+}
+
 bool ChatHandler::HandleGetDistanceCommand(char* args)
 {
     WorldObject* obj = nullptr;


### PR DESCRIPTION
Introduce three new guild chat commands: motd, pnote and offnote. Updates the command table and ChatHandler declarations, and adds implementations to parse arguments, validate guilds/members, and apply changes: SetMOTD + BroadcastEvent for MOTD, and SetPNOTE/SetOFFNOTE on MemberSlot for public and officer notes. Handlers emit appropriate feedback and error messages when guilds or members are not found.

mod to support soap action via website update.